### PR TITLE
escape string so that it can be parsed as json

### DIFF
--- a/seeker/templates/seeker/facets/terms.html
+++ b/seeker/templates/seeker/facets/terms.html
@@ -3,6 +3,6 @@
 <label for="{{ facet.name }}_select">{{ facet.label|capfirst }}</label>
 <select name="{{ facet.field }}" class="form-control facet-select" multiple="multiple" id="{{ facet.name }}_select">
     {% for b in data.buckets %}
-        <option value="{{ b.key }}" data-data='{"key": "{{ b.key|addslashes }}", "doc_count": {{ b.doc_count }}}'{% if b.key in selected %} selected="selected"{% endif %}>{{ b.key }} ({{ b.doc_count }})</option>
+        <option value="{{ b.key }}" data-data='{"key": "{{ b.key|escapejs }}", "doc_count": {{ b.doc_count }}}'{% if b.key in selected %} selected="selected"{% endif %}>{{ b.key }} ({{ b.doc_count }})</option>
     {% endfor %}
 </select>


### PR DESCRIPTION
The addslashes filter I suggested escapes single quotes as well as double quotes. We really only want double quotes escaped, as single is valid json. Escaping a single quote like: D'angelo to D\'angelo breaks with addslashes. Although we could probably get away with a modified version of addslashes that only escapes double quotes, using the full fledged escapejs tag works as well. 