### PR TITLE
Update views, middleware, and models for django 1.10 

### DIFF
--- a/seeker/middleware.py
+++ b/seeker/middleware.py
@@ -13,9 +13,20 @@ class ModelIndexingMiddleware (object):
     Middleware class that automatically indexes any new or deleted model objects.
     """
 
-    def __init__(self):
+    def __init__(self, get_response=None):
         models.signals.post_save.connect(self.handle_save)
         models.signals.post_delete.connect(self.handle_delete)
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = None
+        if hasattr(self, 'process_request'):
+            response = self.process_request(request)
+        if not response:
+            response = self.get_response(request)
+        if hasattr(self, 'process_response'):
+            response = self.process_response(request, response)
+        return response
 
     def handle_save(self, sender, instance, **kwargs):
         try:

--- a/seeker/migrations/0001_initial.py
+++ b/seeker/migrations/0001_initial.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('querystring', models.TextField(blank=True)),
                 ('default', models.BooleanField(default=False)),
                 ('date_created', models.DateTimeField(default=django.utils.timezone.now, editable=False)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': (b'name',),

--- a/seeker/migrations/0002_auto_20150507_0134.py
+++ b/seeker/migrations/0002_auto_20150507_0134.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='savedsearch',
             name='user',
-            field=models.ForeignKey(related_name='seeker_searches', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(related_name='seeker_searches', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
         ),
     ]

--- a/seeker/models.py
+++ b/seeker/models.py
@@ -6,7 +6,7 @@ from django.utils.encoding import python_2_unicode_compatible
 
 @python_2_unicode_compatible
 class SavedSearch (models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='seeker_searches')
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='seeker_searches', on_delete=models.CASCADE)
     name = models.CharField(max_length=100)
     url = models.CharField(max_length=200, db_index=True)
     querystring = models.TextField(blank=True)

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -561,7 +561,7 @@ class SeekerView (View):
                 'page': page,
                 'sort': sort,
                 'saved_search_pk': saved_search.pk if saved_search else '',
-                'table_html': loader.render_to_string(self.results_template, context, context_instance=RequestContext(self.request)),
+                'table_html': loader.render_to_string(self.results_template, context, request=self.request),
                 'facet_data': {facet.field: facet.data(results) for facet in self.get_facets()},
             })
         else:


### PR DESCRIPTION
Copy implementation of django.utils.depcreation.MiddlewareMixin to support both old and current Middleware functionality.

set on_delete attribute for models/migrations to handle deprecation in D1.10
replace context_instance use with request kwarg.