### PR TITLE
store template obj in separate variable, to avoid overwriting

### DIFF
--- a/seeker/views.py
+++ b/seeker/views.py
@@ -55,7 +55,7 @@ class Column (object):
             if issubclass(cls, dsl.DocType):
                 search_templates.append('seeker/%s/%s.html' % (cls._doc_type.name, self.field))
         search_templates.append('seeker/column.html')
-        self.template = loader.select_template(search_templates)
+        self.template_obj = loader.select_template(search_templates)
         return self
 
     def header(self):
@@ -105,7 +105,7 @@ class Column (object):
             'query': self.view.get_keywords(),
         }
         params.update(self.context(result, **kwargs))
-        return self.template.render(Context(params))
+        return self.template_obj.render(Context(params))
 
     def export_value(self, result):
         export_field = self.field if self.export is True else self.export


### PR DESCRIPTION
If a column in a seeker view is created directly (e.g. columns = ['title', Column('effective_date', value_format=date_formatter, sort='effective_date')] vs columns = ['title', 'effective_date'] then there is a bug in the column bind() method. It will set self.template to a template object on the first call to it. In subsequent calls it will then try to pass that template object in the loader.select_template() call, which causes an error. This doesn't occur if strings are used in the initial column list specification, because in that case a Column object is built each time and is not reused. 

It's possible this may be new to django 1.10