### PR TITLE
Seeker search on non-ascii character now works

### DIFF
--- a/seeker/views.py
+++ b/seeker/views.py
@@ -6,6 +6,7 @@ from django.template import Context, RequestContext, loader
 from django.utils import timezone
 from django.utils.encoding import force_text
 from django.utils.html import escape
+from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.views.generic import View
 from elasticsearch_dsl.utils import AttrList
@@ -19,7 +20,6 @@ from .mapping import DEFAULT_ANALYZER
 import collections
 import inspect
 import re
-import urllib
 
 
 class Column (object):
@@ -300,7 +300,7 @@ class SeekerView (View):
             # Make sure display/facet/sort fields maintain their order. Everything else can be sorted alphabetically for consistency.
             if key not in ('d', 'f', 's'):
                 values = sorted(values)
-            parts.extend(urllib.urlencode({key: val}) for val in values)
+            parts.extend(urlencode({key: val}) for val in values)
         return '&'.join(parts)
 
     def get_field_label(self, field_name):


### PR DESCRIPTION
https://www.squishlist.com/ims/bioshare/735/?search=277164&page=1

Used Django's urlencode instead of Python's which works on unicode strings.