### PR TITLE
Indexing changes

### DIFF
--- a/seeker/apps.py
+++ b/seeker/apps.py
@@ -53,4 +53,4 @@ class SeekerConfig (AppConfig):
                 indexer_cls = import_class(indexer)
             except ImportError:
                 logger.error("Error importing indexer '{}' specified in settings.SEEKER_INDEXER".format(indexer))
-            indexer_cls().register_signal_handlers()
+            indexer_cls().connect_signal_handlers()

--- a/seeker/apps.py
+++ b/seeker/apps.py
@@ -47,10 +47,14 @@ class SeekerConfig (AppConfig):
                 except ImportError:
                     pass
 
-        indexer = getattr(settings, 'SEEKER_INDEXER', 'seeker.indexer.ModelIndexer')
-        if indexer is not None:
+        self.indexer = None
+        indexer_module = getattr(settings, 'SEEKER_INDEXER', 'seeker.indexer.ModelIndexer')
+        if indexer_module is not None:
+            indexer_cls = None
             try:
-                indexer_cls = import_class(indexer)
+                indexer_cls = import_class(indexer_module)
             except ImportError:
-                logger.error("Error importing indexer '{}' specified in settings.SEEKER_INDEXER".format(indexer))
-            indexer_cls().connect_signal_handlers()
+                logger.error("Error importing indexer '{}' specified in settings.SEEKER_INDEXER".format(indexer_module))
+            if indexer_cls is not None:
+                self.indexer = indexer_cls()
+                self.indexer.connect_signal_handlers()

--- a/seeker/apps.py
+++ b/seeker/apps.py
@@ -46,3 +46,11 @@ class SeekerConfig (AppConfig):
                         register(cls, app_label=app.label)
                 except ImportError:
                     pass
+
+        indexer = getattr(settings, 'SEEKER_INDEXER', 'seeker.indexer.ModelIndexer')
+        if indexer is not None:
+            try:
+                indexer_cls = import_class(indexer)
+            except ImportError:
+                logger.error("Error importing indexer '{}' specified in settings.SEEKER_INDEXER".format(indexer))
+            indexer_cls().register_signal_handlers()

--- a/seeker/indexer.py
+++ b/seeker/indexer.py
@@ -44,7 +44,7 @@ class ModelIndexer(object):
             logger.exception('Error deleting %s instance: %s', sender, instance)
 
     def handle_m2m_changed(self, sender, instance, action, **kwargs):
-        if action == 'post_add' or action == 'post_remove' or action == 'post_clear':
+        if action in ('post_add', 'post_remove', 'post_clear'):
             try:
                 index(instance)
             except:

--- a/seeker/indexer.py
+++ b/seeker/indexer.py
@@ -36,7 +36,7 @@ class ModelIndexer(object):
             logger.exception('Error deleting %s instance: %s', sender, instance)
 
     def handle_m2m_changed(self, sender, instance, action, **kwargs):
-        if action == 'post_add' or action == 'post_clear' or action == 'post_clear':
+        if action == 'post_add' or action == 'post_remove' or action == 'post_clear':
             try:
                 index(instance)
             except:

--- a/seeker/indexer.py
+++ b/seeker/indexer.py
@@ -11,9 +11,9 @@ class ModelIndexer(object):
     Class that automatically indexes any new or deleted mapped model objects.
     """
 
-    def register_signal_handlers(self):
+    def connect_signal_handlers(self):
         """
-        Register save and delete signal handler for mapped models. Also checks each ModelIndex for any additional signal handling that may be needed. 
+        Connects save and delete signal handler for mapped models. Also checks each ModelIndex for any additional signal handling that may be needed. 
         """
 
         for model_class, document_classes in model_documents.items():
@@ -21,7 +21,15 @@ class ModelIndexer(object):
             signals.post_delete.connect(self.handle_delete, sender=model_class, weak=False)
 
             for document_class in document_classes:
-                document_class.register_additional_signal_handlers(self)
+                document_class.connect_additional_signal_handlers(self)
+
+    def disconnect_signal_handlers(self):
+        for model_class, document_classes in model_documents.items():
+            signals.post_save.disconnect(self.handle_save, sender=model_class, weak=False)
+            signals.post_delete.disconnect(self.handle_delete, sender=model_class, weak=False)
+
+            for document_class in document_classes:
+                document_class.disconnect_additional_signal_handlers(self)
 
     def handle_save(self, sender, instance, **kwargs):
         try:

--- a/seeker/indexer.py
+++ b/seeker/indexer.py
@@ -1,0 +1,45 @@
+from django.db.models import signals
+
+from .registry import model_documents
+from .utils import delete, index
+
+import logging
+logger = logging.getLogger(__name__)
+
+class ModelIndexer(object):
+    """
+    Class that automatically indexes any new or deleted mapped model objects.
+    """
+
+    def register_signal_handlers(self):
+        """
+        Register save and delete signal handler for mapped models. Also checks each ModelIndex for any additional signal handling that may be needed. 
+        """
+
+        for model_class, document_classes in model_documents.items():
+            signals.post_save.connect(self.handle_save, sender=model_class, weak=False)
+            signals.post_delete.connect(self.handle_delete, sender=model_class, weak=False)
+
+            for document_class in document_classes:
+                document_class.register_additional_signal_handlers(self)
+
+    def handle_save(self, sender, instance, **kwargs):
+        try:
+            index(instance)
+        except:
+            logger.exception('Error indexing %s instance: %s', sender, instance)
+
+    def handle_delete(self, sender, instance, **kwargs):
+        try:
+            delete(instance)
+        except:
+            logger.exception('Error deleting %s instance: %s', sender, instance)
+
+    def handle_m2m_changed(self, sender, instance, action, **kwargs):
+        if action == 'post_add' or action == 'post_clear' or action == 'post_clear':
+            try:
+                index(instance)
+            except:
+                logger.exception('Error indexing many to many change %s instance: %s', sender, instance)
+
+

--- a/seeker/mapping.py
+++ b/seeker/mapping.py
@@ -173,12 +173,16 @@ class ModelIndex (Indexable):
         return data
 
     @classmethod
-    def register_additional_signal_handlers(cls, indexer):
+    def connect_additional_signal_handlers(cls, indexer):
         """
             Override to register additional signal handlers to work in conjunction with ``SEEKER_INDEXER`` 
             (e.g. if a mapping includes related data such as a ManyToManyField, a signal could be registered to index 
             on the ManyToManyField save). 
         """
+        pass
+
+    @classmethod
+    def disconnect_additional_signal_handlers(cls, indexer):
         pass
 
     @property

--- a/seeker/mapping.py
+++ b/seeker/mapping.py
@@ -172,6 +172,15 @@ class ModelIndex (Indexable):
         data.update(serialize_object(obj, cls._doc_type.mapping, prepare=cls))
         return data
 
+    @classmethod
+    def register_additional_signal_handlers(cls, indexer):
+        """
+            Override to register additional signal handlers to work in conjunction with ``SEEKER_INDEXER`` 
+            (e.g. if a mapping includes related data such as a ManyToManyField, a signal could be registered to index 
+            on the ManyToManyField save). 
+        """
+        pass
+
     @property
     def instance(self):
         """

--- a/seeker/middleware.py
+++ b/seeker/middleware.py
@@ -3,20 +3,18 @@ from django.db import models
 from .utils import delete, index
 
 import logging
-
+import warnings
 
 logger = logging.getLogger(__name__)
 
-
 class ModelIndexingMiddleware (object):
     """
-    Middleware class that automatically indexes any new or deleted model objects.
+    Deprecated: Middleware class that automatically indexes any new or deleted model objects.
     """
 
     def __init__(self, get_response=None):
-        models.signals.post_save.connect(self.handle_save)
-        models.signals.post_delete.connect(self.handle_delete)
         self.get_response = get_response
+        warnings.warn("ModelIndexingMiddleware is deprecated for seeker. Please utilize seeker.SEEKER_INDEXER setting instead.", DeprecationWarning)
 
     def __call__(self, request):
         response = None
@@ -27,18 +25,6 @@ class ModelIndexingMiddleware (object):
         if hasattr(self, 'process_response'):
             response = self.process_response(request, response)
         return response
-
-    def handle_save(self, sender, instance, **kwargs):
-        try:
-            index(instance)
-        except:
-            logger.exception('Error indexing %s instance: %s', sender, instance)
-
-    def handle_delete(self, sender, instance, **kwargs):
-        try:
-            delete(instance)
-        except:
-            logger.exception('Error deleting %s instance: %s', sender, instance)
 
     def process_request(self, request):
         # This is really just here so Django keeps the middleware installed.


### PR DESCRIPTION
This change was motivated by the desire to trigger an index automatically on ManyToManyFields updates. I decided against doing some  sort of introspection on a ModelIndex mapping, looking for related data. Instead this is really just a slight refactor of the code that provides a spot for registering additional signal handlers that one may want. 

I moved the code to register the signal handlers into its own class that's configurable via a new SEEKER_INDEXER setting. I don't think the code belongs in Middleware since it really isn't request/response driven. The new signal registration is called via the seeker app config. Now, only models who have a corresponding ModelIndex are connected. I also added a connect_additional_signal_handlers hook to ModelIndex. If an index wants to connect additional signals, like listening for ManyToMany changes, then the signals can be connected there. 

I realize signals can be connected / disconnected in other places, but I thought this may organize things a bit. I also realize having an additional signal on ManyToMany fields and having the regular save signal on a model isn't that efficient since it could trigger more than one reindex at a time. It's convenient though, and the only other solution I think would be to index manually. It's a shame, there's no way to determine the current request (if there is one) in model signals. What do you think?