### PR TITLE
add field_template override option

### DIFF
--- a/seeker/views.py
+++ b/seeker/views.py
@@ -250,6 +250,11 @@ class SeekerView (View):
     A dictionary of field label overrides.
     """
 
+    field_templates = {}
+    """
+    A dictionary of field template overrides.
+    """
+
     sort_fields = {}
     """
     A dictionary of sort field overrides.
@@ -357,10 +362,14 @@ class SeekerView (View):
         """
         if field_name in self.field_columns:
             return self.field_columns[field_name]
+        if field_name in self.field_templates:
+            template = self.field_templates[field_name]
+        else: 
+            template = None
         label = self.get_field_label(field_name)
         sort = self.get_field_sort(field_name)
         highlight = self.get_field_highlight(field_name)
-        return Column(field_name, label=label, sort=sort, highlight=highlight)
+        return Column(field_name, label=label, sort=sort, highlight=highlight, template=template)
 
     def get_columns(self):
         """

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -362,10 +362,7 @@ class SeekerView (View):
         """
         if field_name in self.field_columns:
             return self.field_columns[field_name]
-        if field_name in self.field_templates:
-            template = self.field_templates[field_name]
-        else: 
-            template = None
+        template = self.field_templates.get(field_name)
         label = self.get_field_label(field_name)
         sort = self.get_field_sort(field_name)
         highlight = self.get_field_highlight(field_name)


### PR DESCRIPTION
This is useful when a mapping (ModelIndex) is used by multiple
search_views. It makes it easy to add another template option for a
field.