### PR TITLE
Changed get_field_label so if verbose_name is set it displays as set

### DIFF
--- a/seeker/views.py
+++ b/seeker/views.py
@@ -315,7 +315,7 @@ class SeekerView (View):
         try:
             # If the document is a ModelIndex, try to get the verbose_name of the Django field.
             f = self.document.queryset().model._meta.get_field(field_name)
-            return f.verbose_name.capitalize()
+            return f.verbose_name[0].upper() + f.verbose_name[1:]
         except:
             # Otherwise, just make the field name more human-readable.
             return field_name.replace('_', ' ').capitalize()


### PR DESCRIPTION
Previously if verbose_name for a field was  set to something like:
'Verbose Name' it would be changed to 'Verbose name' from .capitalize(),
this update changes the behavior so it will remain as is. Now it only
capitalizes first letter of verbose_name without capitalizing or making
other letters lowercase.