### PR TITLE
add field_templates override option back working with new loading code

### DIFF
--- a/seeker/views.py
+++ b/seeker/views.py
@@ -278,6 +278,11 @@ class SeekerView (View):
     Extra context variables to use when rendering. May be passed via as_view(), or overridden as a property.
     """
     
+    field_templates = {}
+    """
+    A dictionary of field template overrides.
+    """
+    
     _field_templates = {}
     """
     A dictionary of default templates for each field
@@ -359,6 +364,8 @@ class SeekerView (View):
         finds and sets the default template instance for the given field name with the given template.
         """
         search_templates = []
+        if field_name in cls.field_templates:
+            search_templates.append(cls.field_templates[field_name])
         for _cls in inspect.getmro(cls.document):
             if issubclass(_cls, dsl.DocType):
                 search_templates.append('seeker/%s/%s.html' % (_cls._doc_type.name, field_name))


### PR DESCRIPTION
While the new update_field_template does allow the user to update the template (and does make the template loading a lot faster) it makes the process of setting up a template override more complicated than it needs to be. I found that it is easiest when writing views and to go along with the current behavior of other override options to put the field_templates override back and call that from the new find_field_template code. Otherwise you have to load in the template object and after building the class call the update_field_template method which just adds a layer of complexity that doesn't seem necessary for simply overriding the initial template.