### PR TITLE
Make Seeker more Python 3 compatible 

### DIFF
--- a/seeker/utils.py
+++ b/seeker/utils.py
@@ -1,5 +1,5 @@
-from __future__ import unicode_literals
 from django.conf import settings
+from django.utils.encoding import force_text
 from elasticsearch import NotFoundError
 from elasticsearch_dsl.connections import connections
 import elasticsearch_dsl as dsl
@@ -84,7 +84,7 @@ def progress(iterator, count=None, label='', size=40, chars='# ', output=sys.std
     """
     assert len(chars) >= 2
     if label:
-        label = str(label) + ' '
+        label = force_text(label) + ' '
 
     try:
         count = len(iterator)

--- a/seeker/utils.py
+++ b/seeker/utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.conf import settings
 from elasticsearch import NotFoundError
 from elasticsearch_dsl.connections import connections
@@ -83,7 +84,7 @@ def progress(iterator, count=None, label='', size=40, chars='# ', output=sys.std
     """
     assert len(chars) >= 2
     if label:
-        label = unicode(label) + ' '
+        label = str(label) + ' '
 
     try:
         count = len(iterator)

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -371,7 +371,7 @@ class SeekerView (View):
                 search_templates.append('seeker/%s/%s.html' % (_cls._doc_type.name, field_name))
         search_templates.append('seeker/column.html')
         template = loader.select_template(search_templates)
-        existing_templates = list(set(cls._field_templates.itervalues()))
+        existing_templates = list(set(cls._field_templates.values()))
         for existing_template in existing_templates:
             #If the template object already exists just re-use the existing one.
             if template.template.name == existing_template.template.name:
@@ -432,9 +432,19 @@ class SeekerView (View):
                     columns.append(c)
         # Make sure the columns are bound and ordered based on the display fields (selected or default).
         display = self.get_display()
+        visible_columns = []
+        non_visible_columns=[]
         for c in columns:
             c.bind(self, c.field in display)
-        columns.sort(key=lambda c: display.index(c.field) if c.visible else c.label)
+            if c.visible:
+                visible_columns.append(c)
+            else:
+                non_visible_columns.append(c)
+        visible_columns.sort(key=lambda  c: display.index(c.field))
+        non_visible_columns.sort(key=lambda c: c.label)
+        visible_columns.extend(non_visible_columns)
+        columns=visible_columns[:]
+        
         return columns
 
     def get_keywords(self):

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -442,10 +442,8 @@ class SeekerView (View):
                 non_visible_columns.append(c)
         visible_columns.sort(key=lambda  c: display.index(c.field))
         non_visible_columns.sort(key=lambda c: c.label)
-        visible_columns.extend(non_visible_columns)
-        columns=visible_columns[:]
         
-        return columns
+        return visible_columns + non_visible_columns
 
     def get_keywords(self):
         return self.request.GET.get('q', '').strip()


### PR DESCRIPTION
While porting code to Python 3.6, I ran into a couple issues with Seeker. I believe that these changes will improve compatibility with Python 3, while remaining compatible with Python 2.