### PR TITLE
Fix for issues with result sets that are too large for elasticsearch

### DIFF
--- a/seeker/templates/seeker/footer.html
+++ b/seeker/templates/seeker/footer.html
@@ -1,8 +1,7 @@
 {% load seeker %}
 {% load i18n %}
-
 <div class="pull-right">
-    {% seeker_pager results.hits.total page_size=page_size page=page querystring=querystring spread=page_spread %}
+    {% seeker_pager results.hits.total page_size=page_size page=page querystring=querystring spread=page_spread max_results=max_results %}
 </div>
 <p>
     <em>Found {{ results.hits.total|intcomma }} result{{ results.hits.total|pluralize }} in {{ results.took }} millisecond{{ results.took|pluralize }}</em>

--- a/seeker/templates/seeker/pager.html
+++ b/seeker/templates/seeker/pager.html
@@ -1,13 +1,27 @@
 {% load i18n %}
 
 <ul class="pagination">
+    {% if 1 != page.number %}
+        <li><a href="?{{ querystring }}{% if querystring %}&amp;{% endif %}{{ param }}={{ page.number|add:"-1" }}" class="page-link" data-page="{{ page.number|add:"-1" }}">&larr;</a></li>
+    {% endif %}
     {% if 1 not in page_range %}
         <li><a href="?{{ querystring }}{% if querystring %}&amp;{% endif %}{{ param }}=1" class="page-link" data-page="1">1 &hellip;</a></li>
     {% endif %}
     {% for p in page_range %}
         <li{% if p == page.number %} class="active"{% endif %}><a href="?{{ querystring }}{% if querystring %}&amp;{% endif %}{{ param }}={{ p }}" class="page-link" data-page="{{ p }}">{{ p }}</a></li>
     {% endfor %}
-    {% if paginator.num_pages not in page_range %}
+    {% if paginator.num_pages not in page_range and show_last_page %}
         <li><a href="?{{ querystring }}{% if querystring %}&amp;{% endif %}{{ param }}={{ paginator.num_pages }}" class="page-link" data-page="{{ paginator.num_pages }}">&hellip; {{ paginator.num_pages }}</a></li>
     {% endif %}
+    {% if paginator.num_pages != page.number %}
+        <li><a href="?{{ querystring }}{% if querystring %}&amp;{% endif %}{{ param }}={{ page.number|add:"1" }}" class="page-link" data-page="{{ page.number|add:"1" }}">&rarr;</a></li>
+    {% endif %}
 </ul>
+
+{% if not show_last_page and page.number == paginator.num_pages %}
+<script>
+document.addEventListener("DOMContentLoaded", function(event) { 
+    alert('You have reached the end of the available results.\nTo view them all export the results.')
+});
+</script>
+{% endif %}

--- a/seeker/templatetags/seeker.py
+++ b/seeker/templatetags/seeker.py
@@ -66,8 +66,12 @@ def seeker_score(result, max_score=None, template='seeker/score.html'):
 
 
 @register.simple_tag
-def seeker_pager(total, page_size=10, page=1, param='p', querystring='', spread=7, template='seeker/pager.html'):
-    paginator = Paginator(range(total), page_size)
+def seeker_pager(total, page_size=10, page=1, param='p', querystring='', spread=7, template='seeker/pager.html', max_results=None):
+    print total
+    if max_results:
+        paginator = Paginator(range(min(total,(max_results//page_size * page_size))), page_size)
+    else:
+        paginator = Paginator(range(total), page_size)
     if paginator.num_pages < 2:
         return ''
     page = paginator.page(page)
@@ -77,12 +81,17 @@ def seeker_pager(total, page_size=10, page=1, param='p', querystring='', spread=
         page_range = range(start, end)
     else:
         page_range = paginator.page_range
+    if max_results and max_results < page_size * total:
+        show_last_page = False
+    else:
+        show_last_page = True
     return loader.render_to_string(template, {
         'page_range': page_range,
         'paginator': paginator,
         'page': page,
         'param': param,
         'querystring': querystring,
+        'show_last_page' : show_last_page
     })
 
 _phrase_re = re.compile(r'"([^"]*)"')

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -218,6 +218,12 @@ class SeekerView (View):
     The number of pages (not including first and last) to show in the paginator widget.
     """
 
+    max_results = 10000
+    """
+    The number of results seeker can show. Most elasticsearch instances default to 10000.
+    Set it to avoid TransportError pages for large result sets
+    """
+
     can_save = True
     """
     Whether searches for this view can be saved.
@@ -564,6 +570,12 @@ class SeekerView (View):
         page = int(page) if page.isdigit() else 1
         offset = (page - 1) * self.page_size
         results_count = search[0:0].execute().hits.total
+        
+        #check to see if the page is greater than the results in set or greater than the max_results seeker returns for a search
+        #if it is change page to first page.
+        if self.max_results and offset + self.page_size > self.max_results:
+            page = 1
+            offset = 0
         if results_count < offset:
             page = 1
             offset = 0
@@ -586,6 +598,7 @@ class SeekerView (View):
             'page': page,
             'page_size': self.page_size,
             'page_spread': self.page_spread,
+            'max_results': self.max_results,
             'sort': sort,
             'querystring': context_querystring,
             'reset_querystring': self.normalized_querystring(ignore=['p', 's', 'saved_search']),


### PR DESCRIPTION
Previously seeker would show last page even if clicking on that page
would result in a TransportError, now the behavior has changed that if
the result set is larger than the max results you can browse in a sorted
elasticsearch search query, (the default value for this is 10000) The
last page is no longer shown. Arrows are also added in to page by 1. If
the user views the last available page they are notified that there are
more results they can view from the exported results.