### PR TITLE
Added args to command arguments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 docs/_build/
 
 .DS_Store
+.idea/

--- a/seeker/management/commands/reindex.py
+++ b/seeker/management/commands/reindex.py
@@ -1,3 +1,5 @@
+import argparse
+
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from elasticsearch.helpers import bulk
@@ -67,6 +69,7 @@ class Command (BaseCommand):
             dest='cursor',
             default=False,
             help='Use a server-side cursor when fetching data for indexing')
+        parser.add_argument('args', nargs=argparse.REMAINDER)
 
     def handle(self, *args, **options):
         doc_classes = []


### PR DESCRIPTION
Now app names can be used without raising unrecognized argument error.