### PR TITLE
Python 3 compatibility changes

### DIFF
--- a/seeker/templatetags/seeker.py
+++ b/seeker/templatetags/seeker.py
@@ -4,12 +4,11 @@ from django.core.paginator import Paginator
 from django.template import loader
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
-from six.moves.urllib.parse import parse_qsl
+from six.moves.urllib.parse import parse_qsl, urlencode
 import six
 
 import datetime
 import re
-import urllib
 
 
 register = template.Library()
@@ -34,10 +33,10 @@ def seeker_format(value):
 
 @register.filter
 def seeker_filter_querystring(qs, keep):
-    if isinstance(keep, basestring):
+    if isinstance(keep, six.string_types):
         keep = [keep]
     qs_parts = [part for part in parse_qsl(qs, keep_blank_values=True) if part[0] in keep]
-    return urllib.urlencode(qs_parts)
+    return urlencode(qs_parts)
 
 
 @register.simple_tag

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -1047,7 +1047,7 @@ class AdvancedSeekerView (SeekerView):
     """
 
     def __init__(self):
-        if getattr(SeekerView, 'get_search_query_type').__func__ != getattr(self, 'get_search_query_type').__func__:
+        if vars(SeekerView).get('get_search_query_type') != getattr(self, 'get_search_query_type').__func__:
             warnings.warn(
                 "'get_search_query_type' function is deprecated, please use 'get_keyword_query' instead.",
                 DeprecationWarning


### PR DESCRIPTION
- moved an import into six
- removed reference to basestring
- changed deprecation check to work in python 3 as well as 2 - the problem arises from calling getattr on a class: in Python 2 it returns an unbound method, where in 3 it returns a raw function. By accessing the class dictionary directly using vars(), we can get the raw function from the class in both python 2 and 3