### PR TITLE
Fix range filter bug on paging, don't sort on values

### DIFF
--- a/seeker/views.py
+++ b/seeker/views.py
@@ -322,7 +322,6 @@ class SeekerView (View):
             values = data.getlist(key)
             parts.extend(urlencode({key: val}) for val in values)
         return '&'.join(parts)
-    pass
 
     def get_field_label(self, field_name):
         """

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -315,11 +315,11 @@ class SeekerView (View):
         for key in sorted(data):
             if ignore and key in ignore:
                 continue
-            if not data.getlist(key) or not any(data.getlist(key)):
+            values = data.getlist(key)
+            if not any(values):
                 continue
             if key == 'p' and data[key] == '1':
                 continue
-            values = data.getlist(key)
             parts.extend(urlencode({key: val}) for val in values)
         return '&'.join(parts)
 

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -315,16 +315,14 @@ class SeekerView (View):
         for key in sorted(data):
             if ignore and key in ignore:
                 continue
-            if not data[key]:
+            if not data.getlist(key) or not any(data.getlist(key)):
                 continue
             if key == 'p' and data[key] == '1':
                 continue
             values = data.getlist(key)
-            # Make sure display/facet/sort fields maintain their order. Everything else can be sorted alphabetically for consistency.
-            if key not in ('d', 'f', 's'):
-                values = sorted(values)
             parts.extend(urlencode({key: val}) for val in values)
         return '&'.join(parts)
+    pass
 
     def get_field_label(self, field_name):
         """


### PR DESCRIPTION
Only ignore a key if all it's data is empty. In the case of range
filter, we need to know which value we are filtering on (the greater
than or less than) and it is fine if one of those values is Falsy