### PR TITLE
value for TextFacet comes in as a list of one string

### DIFF
--- a/seeker/facets.py
+++ b/seeker/facets.py
@@ -183,7 +183,7 @@ class TextFacet(Facet):
         return Q('bool', should=queries)
 
     def filter(self, search, value):
-        values = value.split(self.delimiter)
+        values = value[0].split(self.delimiter)
         filters = []
         for term in values:
             term = term.strip()


### PR DESCRIPTION
value for old seeker always comes in as a list, please merge this bug fix into 6.0 as well.