### PR TITLE
Setup dropindex command for seeker 6

### DIFF
--- a/seeker/management/commands/dropindex.py
+++ b/seeker/management/commands/dropindex.py
@@ -1,16 +1,16 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from elasticsearch_dsl.connections import connections
-
+from elasticsearch.exceptions import AuthorizationException, NotFoundError
 
 class Command (BaseCommand):
-    help = 'Drops the current ES index, or one that you specify.'
+    help = 'Drops all ES indexes on project with SEEKER_INDEX_PREFIX from settings, or one that you specify. To drop indexes with prefix add wildcard * after prefix of indexes you want deleted'
 
     def add_arguments(self, parser):
         parser.add_argument('--index',
             dest='index',
             default=None,
-            help='The ES index to drop'
+            help='The ES index(ex) to drop'
         )
         parser.add_argument('--using',
             dest='using',
@@ -19,16 +19,24 @@ class Command (BaseCommand):
         )
 
     def handle(self, *args, **options):
-        index = options['index'] or getattr(settings, 'SEEKER_INDEX', 'seeker')
+        try:
+            index_prefix = options['index'] or getattr(settings, 'SEEKER_INDEX_PREFIX', None) + '*'
+        except TypeError:
+            print "Index not correctly defined, define SEEKER_INDEX_PREFIX in settings correctly to drop all "
         connection = options['using'] or 'default'
         es = connections.get_connection(connection)
-
-        print 'Attempting to drop index "%s" using "%s" connection...' % (index, connection)
-        if es.indices.exists(index=index):
-            es.indices.delete(index=index)
-            if es.indices.exists(index=index):
-                print '...The index was NOT dropped.'
-            else:
-                print '...The index was dropped.'
-        else:
-            print '...The index could not be dropped because it does not exist.'
+        try:
+            for index in es.indices.get(index_prefix):
+                print 'Attempting to drop index "%s" using "%s" connection...' % (index, connection)
+                if es.indices.exists(index=index):
+                    es.indices.delete(index=index)
+                    if es.indices.exists(index=index):
+                        print '...The index was NOT dropped.'
+                    else:
+                        print '...The index was dropped.'
+                else:
+                    print '...The index could not be dropped because it does not exist.'
+        except NotFoundError:
+            print 'No index with that name found'
+        except AuthorizationException:
+            print 'You are not authorized to drop that index! (index: %s)' % index_prefix


### PR DESCRIPTION
Will drop all indexes that begin with SEEKER_INDEX_PREFIX setting if set
otherwise drop index from user input if it has auth (enables wildcard)
may want to add in by doc class?