### PR TITLE
2090 Fix inner object searching

### DIFF
--- a/seeker/__init__.py
+++ b/seeker/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.3.4'
+__version__ = '6.3.7'
 
 from .facets import DateRangeFacet, DateTermsFacet, Facet, GlobalTermsFacet, RangeFilter, TermsFacet, YearHistogram, TextFacet
 from .mapping import (

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -699,8 +699,8 @@ class SeekerView(View):
             for field_name in mapping:
                 if mapping[field_name].to_dict().get('analyzer') == self.analyzer:
                     fields.append(prefix + field_name)
-                if hasattr(mapping[field_name], 'properties'):
-                    fields.extend(self.get_search_fields(mapping=mapping[field_name].properties, prefix=prefix + field_name + '.'))
+                if hasattr(mapping[field_name], '_mapping'):
+                    fields.extend(self.get_search_fields(mapping=mapping[field_name]._mapping, prefix=prefix + field_name + '.'))
             return fields
         else:
             return self.get_search_fields(mapping=self.document._doc_type.mapping)


### PR DESCRIPTION
The upgrade from elasticsearch_dsl 5.0 -> 6.0 changed how inner
mappings are accessed through Objects. They must be accessed through the
_mapping attribute, rather than the properties attribute.