### PR TITLE
Drop python 2 support for Django 3.0 compatibility

### DIFF
--- a/seeker/__init__.py
+++ b/seeker/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '6.5.1'
+__version__ = '6.6.0'
 
 from .facets import DateRangeFacet, DateTermsFacet, Facet, GlobalTermsFacet, RangeFilter, TermsFacet, YearHistogram, TextFacet
 from .mapping import (

--- a/seeker/facets.py
+++ b/seeker/facets.py
@@ -3,7 +3,6 @@ import functools
 import numbers
 import operator
 
-import six
 from django.conf import settings
 from django.utils.encoding import smart_text
 from elasticsearch_dsl import A, Q
@@ -18,7 +17,7 @@ class Facet(object):
         'not_between': 'must_not'
     }
     special_operators = {
-        'begins_with': "prefix" 
+        'begins_with': "prefix"
     }
     field = None
     label = None
@@ -35,10 +34,10 @@ class Facet(object):
 
         default_related_column_name = self.field.split('.')[0]
         related_column_name = kwargs.get('related_column_name')
-        self.related_column_name = related_column_name if isinstance(related_column_name, six.string_types) else default_related_column_name
+        self.related_column_name = related_column_name if isinstance(related_column_name, str) else default_related_column_name
 
         self.kwargs = kwargs
-        
+
     @property
     def valid_operators(self):
         return [
@@ -55,7 +54,7 @@ class Facet(object):
 
     def filter(self, search, values):
         return search
-    
+
     def es_query(self, operator, value):
         """
         This function returns the elasticsearch_dsl query object for this facet. It only accepts a single value, multiple values
@@ -63,11 +62,11 @@ class Facet(object):
         """
         if operator not in self.valid_operators:
             raise ValueError(u"'{}' is not a valid operator for the {} facet.".format(operator, self.label))
-        
+
         if operator in self.bool_operators:
             return Q('bool', **{self.bool_operators[operator]: [Q('match', **{self.field: value})]})
         return Q(self.special_operators.get(operator, 'match'), **{self.field: value})
-    
+
     def build_filter_dict(self, results):
         """
         This function returns a dictionary that represents this facet.
@@ -106,7 +105,7 @@ class TermsFacet(Facet):
         # Elasticsearch default size to 10, so we set the default to 2147483647 in order to get all the buckets for the field.
         self.size = size
         self.filter_operator = kwargs.pop('filter_operator', 'or')
-        #option to override default sort by doc_count, can be set to other values by adding the desired values in kwargs
+        # option to override default sort by doc_count, can be set to other values by adding the desired values in kwargs
         self.sorted_by_key = sorted_by_key
         super(TermsFacet, self).__init__(field, **kwargs)
 
@@ -129,11 +128,11 @@ class TermsFacet(Facet):
         """
         if operator not in self.valid_operators:
             raise ValueError(u"'{}' is not a valid operator for a TermsFacet object.".format(operator))
-        
+
         if operator in self.bool_operators:
             return Q('bool', **{self.bool_operators[operator]: [Q('term', **{self.field: value})]})
         return Q(self.special_operators.get(operator, 'term'), **{self.field: value})
-    
+
     def build_filter_dict(self, results):
         filter_dict = super(TermsFacet, self).build_filter_dict(results)
         data = self.data(results)
@@ -144,7 +143,7 @@ class TermsFacet(Facet):
             'operators': self.valid_operators
         })
         return filter_dict
-    
+
     def filter(self, search, values):
         if len(values) > 1:
             if self.filter_operator.lower() == 'and':
@@ -181,7 +180,7 @@ class TextFacet(Facet):
         self.placeholder_text = placeholder_text
         self.lowercase_search_terms = lowercase_search_terms
         super(TextFacet, self).__init__(field, **kwargs)
-        
+
     def _get_aggregation(self, **extra):
         """TextFacet isn't designed to aggregate as it acts as a keyword search, so we return None."""
         return None
@@ -237,6 +236,7 @@ class GlobalTermsFacet(TermsFacet):
 
 
 class DateTermsFacet(TermsFacet):
+
     def _get_aggregation(self, **extra):
         params = {
             'field': self.field,
@@ -286,11 +286,11 @@ class YearHistogram(Facet):
 class RangeFilter(Facet):
     template = 'seeker/facets/range.html'
     advanced_template = 'advanced_seeker/facets/range.html'
-    
+
     def __init__(self, field, **kwargs):
         # ranges is an optional list of dictionaries of pre-defined ranges to aggregate on.
         self.ranges = kwargs.pop('ranges', [])
-        
+
         # use_ranges_in_filter_dict specifies if the pre-defined ranges should be used in complex queries
         self.use_ranges_in_filter_dict = kwargs.pop('use_ranges_in_filter_dict', False)
         if self.ranges:
@@ -310,7 +310,7 @@ class RangeFilter(Facet):
 
     def _get_aggregation(self, **extra):
         # If the facet has pre-defined ranges, this function will return a range aggregation.
-        # If the facet doesn't have pre-defined ranges, this function will return a terms aggregation that aggregates on each value in the range field. 
+        # If the facet doesn't have pre-defined ranges, this function will return a terms aggregation that aggregates on each value in the range field.
         if self.ranges:
             params = {'field': self.field, 'ranges': self.ranges}
             params.update(extra)
@@ -324,7 +324,7 @@ class RangeFilter(Facet):
     def apply(self, search, **extra):
         search.aggs[self.name] = self._get_aggregation(**extra)
         return search
-    
+
     def _get_range_key(self, _range):
         """
         This helper function takes a range dictionary and returns the aggregation key.  Key is an optional argument in elasticsearch.
@@ -332,17 +332,17 @@ class RangeFilter(Facet):
         """
         default_from_key = _range.get("from", "*")
         default_to_key = _range.get("to", "*")
-        
+
         # If a from value was found, we need to cast it as a float since that's how elasticsearch formats the default key.
         if default_from_key != "*":
             default_from_key = float(default_from_key)
         # Same as above, if a to value is defined, cast the value as a float.
         if default_to_key != "*":
             default_to_key = float(default_to_key)
-        
+
         # Create the default "from-to" key
         default_range_key = "{}-{}".format(default_from_key, default_to_key)
-        
+
         # Return the custom key defined in self.ranges or the default key
         return str(_range.get('key', default_range_key))
 
@@ -375,7 +375,7 @@ class RangeFilter(Facet):
                 # This if statement is structured to be cross compatible between seeker and advanced seeker.
                 # If key is unicode (advanced seeker), we check if the key is equal to the range_key.  If it is, we add it to valid keys.
                 # If key is a list (seeker), we check if the range_key is in the list of keys.  If it is, we add it to valid keys.
-                if (isinstance(key, six.string_types) and range_key == key) or (isinstance(key, list) and range_key in key):
+                if (isinstance(key, str) and range_key == key) or (isinstance(key, list) and range_key in key):
                     valid_ranges.append(_range)
             for _range in valid_ranges:
                 # From and To are optional in elasticsearch.  The translated_range dictionary stores the parameters we
@@ -392,7 +392,7 @@ class RangeFilter(Facet):
                 if translated_range:
                     filters.append(self._build_query(translated_range))
         return filters
-    
+
     def _get_filter_from_range_list(self, _range):
         """
         This helper function is designed to take a list of 2 values and build a range query.
@@ -414,7 +414,6 @@ class RangeFilter(Facet):
 
         return self._build_query(r)
 
-
     def es_query(self, query_operator, value):
         """
         This function returns the elasticsearch_dsl query object for the RangeFilter Facet.
@@ -428,12 +427,12 @@ class RangeFilter(Facet):
         # We first check if the query operator is valid.
         if query_operator not in self.valid_operators:
             raise ValueError(u"'{}' is not a valid operator for a RangeFilter object.".format(query_operator))
-        
+
         if isinstance(value, (list, dict)):
             # If value is a list defining the lower and upper bounds of the range, we call _get_filter_from_range_list that returns the DSL Filter object.
             filter = self._get_filter_from_range_list(value)
             query = Q('bool', filter=filter)
-            # A check to see if the query should be wrapped in a parent query defined in self.bool_operators. If not, we return the query as-is. 
+            # A check to see if the query should be wrapped in a parent query defined in self.bool_operators. If not, we return the query as-is.
             if query_operator in self.bool_operators:
                 return Q('bool', **{self.bool_operators[query_operator]: [query]})
             else:
@@ -460,7 +459,7 @@ class RangeFilter(Facet):
     def build_filter_dict(self, results):
         filter_dict = super(RangeFilter, self).build_filter_dict(results)
         if self.ranges and self.use_ranges_in_filter_dict:
-            # If we have self.ranges, the filter is defaulted to a select box for those ranges 
+            # If we have self.ranges, the filter is defaulted to a select box for those ranges
             data = self.data(results)
             values = [''] + sorted([str(bucket['key']) for bucket in data.get('buckets', [])], key=lambda item: str(item).lower())
             filter_dict.update({
@@ -529,6 +528,6 @@ class DateRangeFacet(RangeFilter):
                 raise ValueError(u"The range list can only have 2 values. Received {} values: {}".format(len(_range), _range))
         else:
             raise ValueError(u"Range must either be a list or a dict.  Received: {}".format(type(_range)))
-        _range = self._build_query(r)    
+        _range = self._build_query(r)
         _range._params[self.field]['format'] = self.format
         return _range

--- a/seeker/models.py
+++ b/seeker/models.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from six import python_2_unicode_compatible
+
 import bleach
 
-@python_2_unicode_compatible
+
 class SavedSearch(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='seeker_searches', on_delete=models.CASCADE)
     name = models.CharField(max_length=100, blank=True)
@@ -31,10 +31,9 @@ class SavedSearch(models.Model):
         return { 'pk': self.pk, 'name': bleach.clean(self.name, tags=[], strip=True), 'url': self.url, 'default': self.default }
 
 
-@python_2_unicode_compatible
 class AdvancedSavedSearch(SavedSearch):
     search_object = models.TextField()
-    
+
     class Meta:
         ordering = ('name',)
         verbose_name = 'Advanced Saved Search'

--- a/seeker/models.py
+++ b/seeker/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 import bleach
 
 @python_2_unicode_compatible

--- a/seeker/templatetags/seeker.py
+++ b/seeker/templatetags/seeker.py
@@ -1,17 +1,13 @@
-from __future__ import division
-
 import datetime
 import re
+from urllib.parse import parse_qsl, urlencode
 
-import six
 from django import template
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.core.paginator import Paginator
 from django.template import loader
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
-from six.moves.urllib.parse import parse_qsl, urlencode
-
 
 register = template.Library()
 
@@ -28,14 +24,14 @@ def seeker_format(value):
         return value.strftime('%m/%d/%Y %H:%M:%S')
     if isinstance(value, datetime.date):
         return value.strftime('%m/%d/%Y')
-    if hasattr(value, '__iter__') and not isinstance(value, six.string_types):
+    if hasattr(value, '__iter__') and not isinstance(value, str):
         return ', '.join(force_text(v) for v in value)
     return force_text(value)
 
 
 @register.filter
 def seeker_filter_querystring(qs, keep):
-    if isinstance(keep, six.string_types):
+    if isinstance(keep, str):
         keep = [keep]
     qs_parts = [part for part in parse_qsl(qs, keep_blank_values=True) if part[0] in keep]
     return urlencode(qs_parts)
@@ -50,6 +46,7 @@ def seeker_facet(facet, results, selected=None, **params):
     })
     return loader.render_to_string(facet.template, params)
 
+
 @register.simple_tag
 def advanced_seeker_facet(facet, **params):
     """
@@ -61,13 +58,16 @@ def advanced_seeker_facet(facet, **params):
     })
     return loader.render_to_string(facet.advanced_template, params)
 
+
 @register.simple_tag
 def seeker_column(column, result, **kwargs):
     return column.render(result, **kwargs)
 
+
 @register.simple_tag
 def seeker_column_header(column, results=None):
     return column.header(results)
+
 
 @register.simple_tag
 def seeker_score(result, max_score=None, template='seeker/score.html'):
@@ -113,8 +113,11 @@ def seeker_highlight(text, query, algorithm='english'):
         stemWord = stemmer.stemWord
         stemWords = stemmer.stemWords
     except Exception:
+
         def stemWord(word): return word
+
         def stemWords(words): return words
+
     phrases = _phrase_re.findall(query)
     keywords = [w.lower() for w in re.split(r'\W+', _phrase_re.sub('', query)) if w]
     highlight = set(stemWords(keywords))

--- a/seeker/utils.py
+++ b/seeker/utils.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import importlib
 import sys
 import time

--- a/seeker/views.py
+++ b/seeker/views.py
@@ -9,7 +9,7 @@ import warnings
 from datetime import datetime
 
 import elasticsearch_dsl as dsl
-import six
+
 from django.conf import settings
 from django.contrib import messages
 from django.forms.forms import Form
@@ -32,10 +32,7 @@ from .mapping import DEFAULT_ANALYZER
 from .signals import advanced_search_performed, search_complete
 from .templatetags.seeker import seeker_format
 
-
-
 seekerview_field_templates = {}
-
 
 
 class Column(object):
@@ -70,7 +67,7 @@ class Column(object):
                 self.template_obj = loader.get_template(self.template)
             else:
                 self.template_obj = self.view.get_field_template(self.field)
-        #Set the model_lower variable on Column to the lowercased name of the model on the mapping once view is set above
+        # Set the model_lower variable on Column to the lowercased name of the model on the mapping once view is set above
         try:
             self.model_lower = self.view.document._model
         except AttributeError:
@@ -144,7 +141,7 @@ class Column(object):
                 if index_to_replace is not None:
                     modified_values[index_to_replace] = highlighted_value
             highlight = modified_values
-            
+
         if self.value_format:
             value = self.value_format(value)
             if highlight:
@@ -226,7 +223,7 @@ class SeekerView(View):
     """
     A list of field names to exclude when generating columns.
     """
-    
+
     display = None
     """
     A list of field/column names to display by default.
@@ -288,7 +285,7 @@ class SeekerView(View):
     """
     The number of results to show per page.
     """
-    
+
     available_page_sizes = []
     """
     If set allows user to set options for page size to be changed, (must include the default page_size)
@@ -586,7 +583,7 @@ class SeekerView(View):
         sort = self.get_field_sort(field_name)
         highlight = self.get_field_highlight(field_name)
         header = self.custom_column_headers.get(field_name, None)
-        field_definition  = self.field_definitions.get(field_name)
+        field_definition = self.field_definitions.get(field_name)
         return Column(field_name, label=label, sort=sort, highlight=highlight, header=header, field_definition=field_definition)
 
     def sort_columns(self, columns, display=None):
@@ -599,7 +596,7 @@ class SeekerView(View):
             return columns
         else:
             visible_columns = []
-            non_visible_columns=[]
+            non_visible_columns = []
             for c in columns:
                 if c.visible:
                     visible_columns.append(c)
@@ -624,7 +621,7 @@ class SeekerView(View):
         else:
             # Otherwise, go through and convert any strings to Columns.
             for c in self.columns:
-                if isinstance(c, six.string_types):
+                if isinstance(c, str):
                     if self.exclude and c in self.exclude:
                         continue
                     columns.append(self.make_column(c))
@@ -766,7 +763,6 @@ class SeekerView(View):
             for s in sort:
                 sort_dict.update(self.apply_sort_descriptor(s))
             return sort_dict
-                
 
     def is_initial(self):
         """
@@ -983,7 +979,7 @@ class SeekerView(View):
             # A "sub" method that handles ajax save submissions (and returns JSON, not a redirect)
             if request.is_ajax() and self.use_save_form:
 
-                response_data = {} # All data must be able to flatten to JSON
+                response_data = {}  # All data must be able to flatten to JSON
 
                 # First we check if the user is attempting to overwrite an existing search
                 saved_searches = request.user.seeker_searches.filter(url=request.path)
@@ -1055,6 +1051,7 @@ class SeekerView(View):
 
 
 class AdvancedColumn(Column):
+
     def header(self, results=None):
         cls = '{}_{}'.format(self.view.document._doc_type.name, self.field.replace('.', '_'))
         cls += ' {}_{}'.format(self.view.document.__name__.lower(), self.field.replace('.', '_'))
@@ -1073,7 +1070,7 @@ class AdvancedColumn(Column):
             data_sort = '{}{}'.format(d, self.field)
         else:
             data_sort = self.field
-            
+
         next_sort = 'descending' if sort == 'Ascending' else 'ascending'
         sr_label = (' <span class="sr-only">(%s)</span>' % sort) if sort else ''
 
@@ -1097,7 +1094,7 @@ class AdvancedColumn(Column):
         """
         max_length = 0
         for result in results.hits:
-            field_len = len(six.text_type(result[self.field])) if (self.field in result and result[self.field]) else 0
+            field_len = len(str(result[self.field])) if (self.field in result and result[self.field]) else 0
             max_length = max(max_length, field_len)
         return max_length
 
@@ -1143,7 +1140,7 @@ class AdvancedSeekerView(SeekerView):
     A list of available page sizes. The values must be integers.
     NOTE: These values are NOT enforced, they are simply used for rendering.
     """
-    
+
     boolean_translations = {
         'AND': 'must',
         'OR': 'should'
@@ -1191,6 +1188,7 @@ class AdvancedSeekerView(SeekerView):
     @abc.abstractproperty
     def save_search_url(self):
         pass
+
     """
     This property should return the url of the associated AdvancedSavedSearchView.
     It is set to abstract because it needs to be defined on a site by site basis. None is a valid value if saved searches are not being used.
@@ -1199,6 +1197,7 @@ class AdvancedSeekerView(SeekerView):
     @abc.abstractproperty
     def search_url(self):
         pass
+
     """
     This property should return the url of this seeker view.
     It is set to abstract because it needs to be defined on a site by site basis.
@@ -1300,7 +1299,7 @@ class AdvancedSeekerView(SeekerView):
         highlight = self.get_field_highlight(field_name)
         header = self.custom_column_headers.get(field_name, None)
         val_format = self.value_formats.get(field_name, None)
-        field_definition  = self.field_definitions.get(field_name)
+        field_definition = self.field_definitions.get(field_name)
         return AdvancedColumn(field_name, label=label, sort=sort, highlight=highlight, header=header, value_format=val_format, field_definition=field_definition)
 
     def apply_sort_field(self, column_lookup, sort):
@@ -1313,7 +1312,7 @@ class AdvancedSeekerView(SeekerView):
         """
         Returns the appropriate sort field for a given sort value.
         """
-        
+
         # Make sure we sanitize the sort fields.
         sort_fields = []
         column_lookup = { c.field: c for c in columns }
@@ -1445,14 +1444,13 @@ class AdvancedSeekerView(SeekerView):
         }
 
         json_response = {
-            'filters': [facet.build_filter_dict(aggregation_results) for facet in facet_lookup.values()], # Relies on the default 'apply_aggregations' being applied.
+            'filters': [facet.build_filter_dict(aggregation_results) for facet in facet_lookup.values()],  # Relies on the default 'apply_aggregations' being applied.
             'search_object': self.search_object
         }
 
         self.modify_aggregation_json_response(json_response, context)
 
         return JsonResponse(json_response)
-
 
     def initial_facet_query(self):
 
@@ -1544,7 +1542,7 @@ class AdvancedSeekerView(SeekerView):
         self.modify_results_context(context)
 
         json_response = {
-            'filters': [facet.build_filter_dict(aggregation_results) for facet in facet_lookup.values()], # Relies on the default 'apply_aggregations' being applied.
+            'filters': [facet.build_filter_dict(aggregation_results) for facet in facet_lookup.values()],  # Relies on the default 'apply_aggregations' being applied.
             'table_html': loader.render_to_string(self.results_template, context, request=self.request),
             'search_object': self.search_object
         }
@@ -1668,6 +1666,7 @@ class AdvancedSeekerView(SeekerView):
         A helper method called when ``_export`` is present in the http request. Returns a ``StreamingHttpResponse``
         that yields CSV data for all matching results.
         """
+
         def csv_escape(value):
             if isinstance(value, (list, tuple)):
                 value = '; '.join(force_text(v) for v in value)
@@ -1792,7 +1791,7 @@ class AdvancedSavedSearchView(View):
             if delete:
                 if saved_search:
                     saved_search.delete()
-                saved_search = None # 'saved_search' will still hold the python object of the saved search that was just deleted
+                saved_search = None  # 'saved_search' will still hold the python object of the saved search that was just deleted
             elif modify_default:
                 if modify_default == 'set':
                     saved_search.default = True


### PR DESCRIPTION
Django 3.0 removed Python 2 compatibility libraries. Switching this import to six makes seeker work with Django 3.0/3.1. I have not been able to find any other incompatibilities.