### PR TITLE
2455 – Seeker Reindex -- display Index Name

### DIFF
--- a/seeker/management/commands/reindex.py
+++ b/seeker/management/commands/reindex.py
@@ -22,7 +22,9 @@ def reindex(es, doc_class, index, options):
             action.update(doc)
             yield action
 
-    actions = get_actions() if options['quiet'] else progress(get_actions(), count=doc_class.count(), label=doc_class.__name__)
+    actions = (
+        get_actions() if options['quiet'] else progress(get_actions(), count=doc_class.count(), label=f"{doc_class.__name__} ({index})")
+    )
     bulk(es, actions)
     es.indices.refresh(index=index)
 


### PR DESCRIPTION
Made the reindex command display the indexes being reindexed in parentheses next to the mapping class. ex:

\<Mapping Class> (\<index>) [########################################] 6/6 100% - 00:00, 56.07 iters/sec